### PR TITLE
Implement helm charts, kustomize files and ci tests for k8s deployments

### DIFF
--- a/.github/workflows/k8s-validation.yml
+++ b/.github/workflows/k8s-validation.yml
@@ -1,0 +1,241 @@
+name: Kubernetes Validation
+
+on:
+  pull_request:
+    paths:
+      - 'k8s/**'
+      - '.github/workflows/k8s-validation.yml'
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - 'k8s/**'
+      - '.github/workflows/k8s-validation.yml'
+  workflow_dispatch:
+
+jobs:
+  helm-lint:
+    name: Helm Chart Linting
+    runs-on: ubuntu-latest
+    container:
+      image: alpine/helm:3.14.0
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Lint Helm chart
+        run: |
+          helm lint k8s/helm/hytale-server
+
+      - name: Helm template validation
+        run: |
+          helm template hytale-server k8s/helm/hytale-server --debug
+
+      - name: Validate with test values
+        run: |
+          # Test with default values
+          helm template hytale-server k8s/helm/hytale-server > /dev/null
+          echo "✓ Default values validated"
+          
+          # Test with CurseForge enabled
+          helm template hytale-server k8s/helm/hytale-server \
+            --set curseforge.enabled=true \
+            --set curseforge.apiKey=test-key \
+            --set 'curseforge.mods[0]=test-mod' > /dev/null
+          echo "✓ CurseForge configuration validated"
+          
+          # Test with backups enabled
+          helm template hytale-server k8s/helm/hytale-server \
+            --set hytale.backup.enabled=true > /dev/null
+          echo "✓ Backup configuration validated"
+
+      - name: Check Chart.yaml version
+        run: |
+          VERSION=$(grep '^version:' k8s/helm/hytale-server/Chart.yaml | awk '{print $2}')
+          if [ -z "$VERSION" ]; then
+            echo "Error: Chart version not found"
+            exit 1
+          fi
+          echo "Chart version: $VERSION"
+
+  kustomize-validate:
+    name: Kustomize Validation
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.19
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Kustomize
+        run: |
+          apk add --no-cache curl bash
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          mv kustomize /usr/local/bin/
+
+      - name: Validate Kustomize base
+        run: |
+          echo "Validating base kustomization..."
+          kustomize build k8s/kustomize/base > /dev/null
+          echo "✓ Base kustomization is valid"
+
+      - name: Validate development overlay
+        run: |
+          echo "Validating development overlay..."
+          kustomize build k8s/kustomize/overlays/development > /dev/null
+          echo "✓ Development overlay is valid"
+
+      - name: Validate production overlay
+        run: |
+          echo "Validating production overlay..."
+          kustomize build k8s/kustomize/overlays/production > /dev/null
+          echo "✓ Production overlay is valid"
+
+      - name: Check for deprecated fields
+        run: |
+          echo "Checking for deprecated Kustomize fields..."
+          
+          # Check for deprecated 'bases' field
+          if grep -r "^bases:" k8s/kustomize/; then
+            echo "Error: Deprecated 'bases' field found. Use 'resources' instead."
+            exit 1
+          fi
+          
+          # Check for deprecated 'commonLabels' field
+          if grep -r "^commonLabels:" k8s/kustomize/; then
+            echo "Warning: Deprecated 'commonLabels' field found. Consider using 'labels' instead."
+            # Don't fail, just warn
+          fi
+          
+          echo "✓ No critical deprecated fields found"
+
+  yaml-lint:
+    name: YAML Linting
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.11-alpine
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install yamllint
+        run: pip install --no-cache-dir yamllint
+
+      - name: Lint YAML files
+        run: |
+          cat > .yamllint.yml << EOF
+          extends: default
+          rules:
+            line-length:
+              max: 120
+              level: warning
+            indentation:
+              spaces: 2
+            trailing-spaces: enable
+            comments:
+              min-spaces-from-content: 1
+            document-start: disable
+            truthy:
+              allowed-values: ['true', 'false', 'on', 'off']
+          EOF
+          
+          yamllint k8s/ || true
+
+  kubernetes-validate:
+    name: Kubernetes Manifest Validation
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:3.19
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install tools
+        run: |
+          apk add --no-cache curl bash
+          
+          # Install kubectl
+          curl -LO "https://dl.k8s.io/release/v1.29.0/bin/linux/amd64/kubectl"
+          chmod +x kubectl
+          mv kubectl /usr/local/bin/
+          
+          # Install helm
+          curl -fsSL https://get.helm.sh/helm-v3.14.0-linux-amd64.tar.gz | tar -xz
+          mv linux-amd64/helm /usr/local/bin/
+          
+          # Install kustomize
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          mv kustomize /usr/local/bin/
+          
+          # Install kubeconform
+          curl -L https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz | tar xz
+          mv kubeconform /usr/local/bin/
+
+      - name: Validate Helm-generated manifests
+        run: |
+          # Generate manifests for schema validation
+          helm template hytale-server k8s/helm/hytale-server > /tmp/helm-manifests.yaml
+          echo "✓ Helm manifests generated successfully"
+
+      - name: Validate Kustomize-generated manifests
+        run: |
+          # Generate manifests for schema validation
+          kustomize build k8s/kustomize/overlays/development > /tmp/kustomize-dev-manifests.yaml
+          echo "✓ Kustomize development manifests generated successfully"
+          
+          kustomize build k8s/kustomize/overlays/production > /tmp/kustomize-prod-manifests.yaml
+          echo "✓ Kustomize production manifests generated successfully"
+
+      - name: Validate against Kubernetes schemas
+        run: |
+          echo "Validating Helm manifests..."
+          helm template hytale-server k8s/helm/hytale-server | kubeconform -strict -summary
+          
+          echo "Validating Kustomize development overlay..."
+          kustomize build k8s/kustomize/overlays/development | kubeconform -strict -summary
+          
+          echo "Validating Kustomize production overlay..."
+          kustomize build k8s/kustomize/overlays/production | kubeconform -strict -summary
+
+  summary:
+    name: Validation Summary
+    runs-on: ubuntu-latest
+    needs: [helm-lint, kustomize-validate, yaml-lint, kubernetes-validate]
+    if: always()
+    steps:
+      - name: Check all jobs
+        run: |
+          echo "## Kubernetes Validation Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          if [ "${{ needs.helm-lint.result }}" == "success" ]; then
+            echo "Helm chart linting passed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Helm chart linting failed" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          if [ "${{ needs.kustomize-validate.result }}" == "success" ]; then
+            echo "Kustomize validation passed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Kustomize validation failed" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          if [ "${{ needs.yaml-lint.result }}" == "success" ]; then
+            echo "YAML linting passed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "YAML linting failed" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          if [ "${{ needs.kubernetes-validate.result }}" == "success" ]; then
+            echo "Kubernetes manifest validation passed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Kubernetes manifest validation failed" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Fail if any job failed
+        if: |
+          needs.helm-lint.result == 'failure' ||
+          needs.kustomize-validate.result == 'failure' ||
+          needs.kubernetes-validate.result == 'failure'
+        run: exit 1

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,544 @@
+# Kubernetes Deployments
+
+This directory contains Kubernetes deployment configurations for the Hytale server using both Kustomize and Helm.
+
+## Directory Structure
+
+```
+k8s/
+├── kustomize/
+│   ├── base/                  # Base Kustomize configuration
+│   └── overlays/
+│       ├── development/       # Dev environment overlay
+│       └── production/        # Production environment overlay
+└── helm/
+    └── hytale-server/         # Helm chart
+```
+
+## Prerequisites
+
+- Kubernetes cluster (v1.20+)
+- `kubectl` configured to access your cluster
+- For Kustomize: `kubectl` with built-in Kustomize support (v1.14+)
+- For Helm: Helm 3.x installed
+
+## Option 1: Deploy with Kustomize
+
+Kustomize provides a template-free way to customize Kubernetes configurations.
+
+### Deploy Development Environment
+
+```bash
+kubectl apply -k k8s/kustomize/overlays/development
+```
+
+### Deploy Production Environment
+
+```bash
+kubectl apply -k k8s/kustomize/overlays/production
+```
+
+### View Generated Configuration
+
+```bash
+kubectl kustomize k8s/kustomize/overlays/production
+```
+
+### Customize
+
+Edit the overlay files to customize your deployment:
+
+- **Development**: `k8s/kustomize/overlays/development/`
+- **Production**: `k8s/kustomize/overlays/production/`
+
+Common customizations:
+- Resource limits/requests
+- Environment variables
+- Storage size
+- Service type
+
+### Uninstall
+
+```bash
+kubectl delete -k k8s/kustomize/overlays/production
+```
+
+## Option 2: Deploy with Helm
+
+Helm provides a more flexible templating system with values.yaml configuration.
+
+### Install
+
+```bash
+# Install with default values
+helm install hytale-server k8s/helm/hytale-server
+
+# Install with custom values
+helm install hytale-server k8s/helm/hytale-server -f my-values.yaml
+
+# Install in a specific namespace
+helm install hytale-server k8s/helm/hytale-server --namespace hytale --create-namespace
+```
+
+### Upgrade
+
+```bash
+helm upgrade hytale-server k8s/helm/hytale-server
+```
+
+### Uninstall
+
+```bash
+helm uninstall hytale-server
+```
+
+### Configuration
+
+The Helm chart can be configured via `values.yaml`. See the [values.yaml](helm/hytale-server/values.yaml) file for all available options.
+
+#### Common Configurations
+
+**Change resources:**
+
+```yaml
+resources:
+  requests:
+    memory: "8Gi"
+    cpu: "4000m"
+  limits:
+    memory: "16Gi"
+    cpu: "8000m"
+```
+
+**Enable backups:**
+
+```yaml
+hytale:
+  backup:
+    enabled: true
+    frequencyMinutes: 60
+    maxCount: 10
+```
+
+**Configure CurseForge mods:**
+
+```yaml
+curseforge:
+  enabled: true
+  apiKey: "your-api-key"
+  mods:
+    - "advanced-item-info"
+    - "project-id:12345"
+  autoUpdate: true
+  releaseChannel: "release"
+```
+
+**Use NodePort service:**
+
+```yaml
+service:
+  type: NodePort
+```
+
+**Use existing PVC:**
+
+```yaml
+persistence:
+  enabled: true
+  existingClaim: "my-existing-pvc"
+```
+
+### Helm Values Examples
+
+Create a custom `values.yaml` file:
+
+**Development Environment:**
+
+```yaml
+# dev-values.yaml
+jvm:
+  xms: "2G"
+  xmx: "4G"
+
+resources:
+  requests:
+    memory: "2Gi"
+    cpu: "1000m"
+  limits:
+    memory: "4Gi"
+    cpu: "2000m"
+
+hytale:
+  authMode: "offline"
+  disableSentry: true
+  autoUpdate: false
+
+persistence:
+  size: 10Gi
+```
+
+```bash
+helm install hytale-dev k8s/helm/hytale-server -f dev-values.yaml
+```
+
+**Production Environment:**
+
+```yaml
+# prod-values.yaml
+jvm:
+  xms: "4G"
+  xmx: "8G"
+
+resources:
+  requests:
+    memory: "8Gi"
+    cpu: "4000m"
+  limits:
+    memory: "16Gi"
+    cpu: "8000m"
+
+hytale:
+  authMode: "authenticated"
+  autoUpdate: true
+  backup:
+    enabled: true
+    frequencyMinutes: 60
+    maxCount: 24
+
+persistence:
+  size: 50Gi
+  storageClass: "fast-ssd"
+
+service:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+```
+
+```bash
+helm install hytale-prod k8s/helm/hytale-server -f prod-values.yaml --namespace hytale-prod --create-namespace
+```
+
+## Post-Deployment Steps
+
+### 1. Watch Deployment
+
+```bash
+kubectl get pods -n hytale -w
+```
+
+### 2. View Logs
+
+```bash
+kubectl logs -n hytale -f deployment/hytale-server
+```
+
+### 3. First-Time Downloader Authentication
+
+On first run, watch the logs for the downloader authorization URL and device code:
+
+```bash
+kubectl logs -n hytale -f deployment/hytale-server
+```
+
+Open the URL in your browser and enter the device code.
+
+### 4. Server Authentication (Required)
+
+After the server starts, you must authenticate it:
+
+```bash
+# Attach to the server console
+kubectl attach -n hytale -it deployment/hytale-server
+
+# In the console, run:
+/auth persistence Encrypted
+/auth login device
+
+# Follow the URL + device code shown
+# If multiple profiles are shown:
+/auth select <number>
+
+# Detach: Ctrl-p then Ctrl-q
+```
+
+### 5. Get Server Address
+
+**For LoadBalancer:**
+
+```bash
+kubectl get svc -n hytale hytale-server
+```
+
+Look for the `EXTERNAL-IP` column.
+
+**For NodePort:**
+
+```bash
+kubectl get svc -n hytale hytale-server -o jsonpath='{.spec.ports[0].nodePort}'
+```
+
+Connect using: `<node-ip>:<node-port>`
+
+## Storage Considerations
+
+### Persistent Volume
+
+The server data is stored in a PersistentVolumeClaim (PVC). Ensure your cluster has a storage provisioner configured.
+
+**Recommended storage sizes:**
+- Development: 10-20 GB
+- Production: 50-100 GB
+
+### Storage Class
+
+Specify a storage class for better performance:
+
+**Kustomize:** Edit `persistentvolumeclaim.yaml`
+
+```yaml
+spec:
+  storageClassName: fast-ssd
+```
+
+**Helm:**
+
+```yaml
+persistence:
+  storageClass: "fast-ssd"
+```
+
+### Backup Strategy
+
+1. **Enable built-in backups** (recommended):
+
+```yaml
+hytale:
+  backup:
+    enabled: true
+    frequencyMinutes: 60
+    maxCount: 24
+```
+
+2. **Snapshot the PVC** using your cloud provider's snapshot features
+
+3. **Use Velero** for cluster-level backups
+
+## Network Configuration
+
+### UDP Protocol
+
+Hytale uses **QUIC over UDP** on port 5520. Ensure your cluster and cloud provider support UDP LoadBalancer services.
+
+### Cloud Provider Notes
+
+**AWS:**
+- Use Network Load Balancer (NLB):
+  ```yaml
+  service:
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+  ```
+
+**Azure:**
+- Standard Load Balancer supports UDP
+
+**GCP:**
+- Network Load Balancer supports UDP
+
+**DigitalOcean:**
+- Load Balancer supports UDP
+
+### NodePort Alternative
+
+If LoadBalancer is not available:
+
+```yaml
+service:
+  type: NodePort
+```
+
+## Security
+
+### Run as Non-Root
+
+Both configurations run the container as user `1000:1000` (non-root).
+
+### Secrets Management
+
+**Never commit secrets to Git!**
+
+**Helm - Using Kubernetes Secrets:**
+
+```bash
+# Create secret separately
+kubectl create secret generic hytale-secrets \
+  --from-literal=curseforge-api-key="your-api-key" \
+  -n hytale
+
+# Reference in values.yaml
+curseforge:
+  enabled: true
+  apiKeySecret:
+    name: hytale-secrets
+    key: curseforge-api-key
+```
+
+**Sealed Secrets / External Secrets:**
+
+For production, use:
+- [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets)
+- [External Secrets Operator](https://external-secrets.io/)
+- Cloud provider secret managers (AWS Secrets Manager, Azure Key Vault, GCP Secret Manager)
+
+## Monitoring & Observability
+
+### View Logs
+
+```bash
+# Follow logs
+kubectl logs -n hytale -f deployment/hytale-server
+
+# View last 100 lines
+kubectl logs -n hytale deployment/hytale-server --tail=100
+```
+
+### Resource Usage
+
+```bash
+kubectl top pod -n hytale
+```
+
+### Events
+
+```bash
+kubectl get events -n hytale --sort-by='.lastTimestamp'
+```
+
+## Troubleshooting
+
+### Pod Not Starting
+
+```bash
+kubectl describe pod -n hytale <pod-name>
+kubectl logs -n hytale <pod-name>
+```
+
+### Storage Issues
+
+```bash
+kubectl get pvc -n hytale
+kubectl describe pvc -n hytale hytale-server-data
+```
+
+### Service Not Accessible
+
+```bash
+kubectl get svc -n hytale
+kubectl describe svc -n hytale hytale-server
+```
+
+### Authentication Issues
+
+See the main [troubleshooting guide](../docs/image/troubleshooting.md).
+
+## Advanced Topics
+
+### Multi-Server Deployment
+
+To run multiple Hytale servers in the same cluster:
+
+```bash
+# Install multiple releases with different names
+helm install hytale-server1 k8s/helm/hytale-server -f server1-values.yaml
+helm install hytale-server2 k8s/helm/hytale-server -f server2-values.yaml
+```
+
+### StatefulSet (Alternative)
+
+For more predictable pod naming and ordered deployments, consider converting to StatefulSet.
+
+### Resource Limits
+
+Always set resource limits to prevent resource exhaustion:
+
+```yaml
+resources:
+  requests:
+    memory: "4Gi"
+    cpu: "2000m"
+  limits:
+    memory: "8Gi"
+    cpu: "4000m"
+```
+
+### Affinity Rules
+
+Pin pods to specific nodes:
+
+```yaml
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: node-type
+          operator: In
+          values:
+          - game-server
+```
+
+## CI/CD Integration
+
+### GitOps with ArgoCD
+
+```yaml
+# argocd-app.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hytale-server
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/your-org/your-repo
+    targetRevision: HEAD
+    path: k8s/helm/hytale-server
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: hytale
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+```
+
+### Flux CD
+
+```yaml
+# helmrelease.yaml
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: hytale-server
+  namespace: hytale
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: ./k8s/helm/hytale-server
+      sourceRef:
+        kind: GitRepository
+        name: hytale-server-repo
+  values:
+    # Your values here
+```
+
+## References
+
+- [Main Documentation](../docs/image/README.md)
+- [Quickstart Guide](../docs/image/quickstart.md)
+- [Configuration Guide](../docs/image/configuration.md)
+- [Troubleshooting](../docs/image/troubleshooting.md)

--- a/k8s/helm/hytale-server/.helmignore
+++ b/k8s/helm/hytale-server/.helmignore
@@ -1,0 +1,31 @@
+# .helmignore patterns
+# Ignore files that shouldn't be included in the Helm chart package
+
+# Version control
+.git/
+.gitignore
+.gitattributes
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+.travis.yml
+
+# Documentation
+README.md
+NOTES.txt
+
+# Development files
+*.swp
+*.bak
+*.tmp
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE files
+.idea/
+.vscode/
+*.iml

--- a/k8s/helm/hytale-server/Chart.yaml
+++ b/k8s/helm/hytale-server/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: hytale-server
+description: A Helm chart for deploying Hytale dedicated server on Kubernetes
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - hytale
+  - game-server
+  - minecraft
+home: https://github.com/hybrowse/hytale-server-docker
+sources:
+  - https://github.com/hybrowse/hytale-server-docker
+maintainers:
+  - name: Hybrowse
+    url: https://hybrowse.gg

--- a/k8s/helm/hytale-server/templates/NOTES.txt
+++ b/k8s/helm/hytale-server/templates/NOTES.txt
@@ -1,0 +1,31 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "hytale-server.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "Hytale server available at: udp://$NODE_IP:$NODE_PORT"
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status by running: kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "hytale-server.fullname" . }}
+  
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "hytale-server.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo "Hytale server available at: udp://$SERVICE_IP:{{ .Values.service.port }}"
+{{- else if contains "ClusterIP" .Values.service.type }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "hytale-server.fullname" . }} 5520:5520/udp
+  echo "Hytale server available at: udp://127.0.0.1:5520"
+{{- end }}
+
+2. Authenticate the server (required for player connections):
+
+   Attach to the server console:
+   kubectl attach --namespace {{ .Release.Namespace }} -it deployment/{{ include "hytale-server.fullname" . }}
+
+   Then run in the server console:
+   /auth persistence Encrypted
+   /auth login device
+
+   Follow the URL and device code shown.
+
+   Detach from console: Ctrl-p then Ctrl-q
+
+3. View server logs:
+   kubectl logs --namespace {{ .Release.Namespace }} -f deployment/{{ include "hytale-server.fullname" . }}

--- a/k8s/helm/hytale-server/templates/_helpers.tpl
+++ b/k8s/helm/hytale-server/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hytale-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "hytale-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hytale-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "hytale-server.labels" -}}
+helm.sh/chart: {{ include "hytale-server.chart" . }}
+{{ include "hytale-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "hytale-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "hytale-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "hytale-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "hytale-server.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/k8s/helm/hytale-server/templates/deployment.yaml
+++ b/k8s/helm/hytale-server/templates/deployment.yaml
@@ -1,0 +1,270 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "hytale-server.fullname" . }}
+  labels:
+    {{- include "hytale-server.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "hytale-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "hytale-server.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "hytale-server.serviceAccountName" . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+      - name: {{ .Chart.Name }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        stdin: true
+        tty: true
+        ports:
+        - name: quic
+          containerPort: 5520
+          protocol: UDP
+        env:
+        - name: HYTALE_AUTO_DOWNLOAD
+          value: {{ .Values.hytale.autoDownload | quote }}
+        - name: HYTALE_AUTO_UPDATE
+          value: {{ .Values.hytale.autoUpdate | quote }}
+        - name: HYTALE_BIND
+          value: {{ .Values.hytale.bind | quote }}
+        - name: HYTALE_AUTH_MODE
+          value: {{ .Values.hytale.authMode | quote }}
+        - name: HYTALE_DISABLE_SENTRY
+          value: {{ .Values.hytale.disableSentry | quote }}
+        - name: HYTALE_ACCEPT_EARLY_PLUGINS
+          value: {{ .Values.hytale.acceptEarlyPlugins | quote }}
+        - name: HYTALE_ENABLE_BACKUP
+          value: {{ .Values.hytale.backup.enabled | quote }}
+        {{- if .Values.hytale.backup.enabled }}
+        - name: HYTALE_BACKUP_FREQUENCY_MINUTES
+          value: {{ .Values.hytale.backup.frequencyMinutes | quote }}
+        - name: HYTALE_BACKUP_MAX_COUNT
+          value: {{ .Values.hytale.backup.maxCount | quote }}
+        {{- if .Values.hytale.backup.dir }}
+        - name: HYTALE_BACKUP_DIR
+          value: {{ .Values.hytale.backup.dir | quote }}
+        {{- end }}
+        {{- end }}
+        - name: JVM_XMS
+          value: {{ .Values.jvm.xms | quote }}
+        - name: JVM_XMX
+          value: {{ .Values.jvm.xmx | quote }}
+        {{- if .Values.jvm.extraArgs }}
+        - name: JVM_EXTRA_ARGS
+          value: {{ .Values.jvm.extraArgs | quote }}
+        {{- end }}
+        - name: ENABLE_AOT
+          value: {{ .Values.aot.enabled | quote }}
+        {{- if .Values.hytale.allowOp }}
+        - name: HYTALE_ALLOW_OP
+          value: "true"
+        {{- end }}
+        {{- if .Values.hytale.bare }}
+        - name: HYTALE_BARE
+          value: "true"
+        {{- end }}
+        {{- if .Values.hytale.bootCommand }}
+        - name: HYTALE_BOOT_COMMAND
+          value: {{ .Values.hytale.bootCommand | quote }}
+        {{- end }}
+        {{- if .Values.hytale.disableAssetCompare }}
+        - name: HYTALE_DISABLE_ASSET_COMPARE
+          value: "true"
+        {{- end }}
+        {{- if .Values.hytale.disableCpbBuild }}
+        - name: HYTALE_DISABLE_CPB_BUILD
+          value: "true"
+        {{- end }}
+        {{- if .Values.hytale.disableFileWatcher }}
+        - name: HYTALE_DISABLE_FILE_WATCHER
+          value: "true"
+        {{- end }}
+        {{- if .Values.hytale.earlyPluginsPath }}
+        - name: HYTALE_EARLY_PLUGINS_PATH
+          value: {{ .Values.hytale.earlyPluginsPath | quote }}
+        {{- end }}
+        {{- if .Values.hytale.eventDebug }}
+        - name: HYTALE_EVENT_DEBUG
+          value: "true"
+        {{- end }}
+        {{- if .Values.hytale.forceNetworkFlush }}
+        - name: HYTALE_FORCE_NETWORK_FLUSH
+          value: "true"
+        {{- end }}
+        {{- if .Values.hytale.generateSchema }}
+        - name: HYTALE_GENERATE_SCHEMA
+          value: "true"
+        {{- end }}
+        {{- if .Values.hytale.modsPath }}
+        - name: HYTALE_MODS_PATH
+          value: {{ .Values.hytale.modsPath | quote }}
+        {{- end }}
+        {{- if .Values.hytale.ownerName }}
+        - name: HYTALE_OWNER_NAME
+          value: {{ .Values.hytale.ownerName | quote }}
+        {{- end }}
+        {{- if .Values.hytale.ownerUUID }}
+        - name: HYTALE_OWNER_UUID
+          value: {{ .Values.hytale.ownerUUID | quote }}
+        {{- end }}
+        {{- if .Values.hytale.prefabCachePath }}
+        - name: HYTALE_PREFAB_CACHE_PATH
+          value: {{ .Values.hytale.prefabCachePath | quote }}
+        {{- end }}
+        {{- if .Values.hytale.singleplayer }}
+        - name: HYTALE_SINGLEPLAYER
+          value: "true"
+        {{- end }}
+        {{- if .Values.hytale.universePath }}
+        - name: HYTALE_UNIVERSE_PATH
+          value: {{ .Values.hytale.universePath | quote }}
+        {{- end }}
+        {{- if .Values.hytale.validateAssets }}
+        - name: HYTALE_VALIDATE_ASSETS
+          value: "true"
+        {{- end }}
+        {{- if .Values.hytale.validateWorldGen }}
+        - name: HYTALE_VALIDATE_WORLD_GEN
+          value: "true"
+        {{- end }}
+        {{- if .Values.hytale.worldGenPath }}
+        - name: HYTALE_WORLD_GEN_PATH
+          value: {{ .Values.hytale.worldGenPath | quote }}
+        {{- end }}
+        {{- if .Values.hytale.sessionToken }}
+        - name: HYTALE_SERVER_SESSION_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "hytale-server.fullname" . }}-secrets
+              key: session-token
+        {{- end }}
+        {{- if .Values.hytale.identityToken }}
+        - name: HYTALE_SERVER_IDENTITY_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "hytale-server.fullname" . }}-secrets
+              key: identity-token
+        {{- end }}
+        {{- if .Values.hytale.downloader.patchline }}
+        - name: HYTALE_DOWNLOADER_PATCHLINE
+          value: {{ .Values.hytale.downloader.patchline | quote }}
+        {{- end }}
+        {{- if .Values.hytale.downloader.skipUpdateCheck }}
+        - name: HYTALE_DOWNLOADER_SKIP_UPDATE_CHECK
+          value: "true"
+        {{- end }}
+        {{- if .Values.hytale.downloader.keepGameZip }}
+        - name: HYTALE_KEEP_GAME_ZIP
+          value: "true"
+        {{- end }}
+        {{- if .Values.curseforge.enabled }}
+        - name: HYTALE_CURSEFORGE_MODS
+          value: {{ join " " .Values.curseforge.mods | quote }}
+        {{- if .Values.curseforge.apiKeySecret.name }}
+        - name: HYTALE_CURSEFORGE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.curseforge.apiKeySecret.name }}
+              key: {{ .Values.curseforge.apiKeySecret.key }}
+        {{- else if .Values.curseforge.apiKey }}
+        - name: HYTALE_CURSEFORGE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "hytale-server.fullname" . }}-secrets
+              key: curseforge-api-key
+        {{- end }}
+        - name: HYTALE_CURSEFORGE_AUTO_UPDATE
+          value: {{ .Values.curseforge.autoUpdate | quote }}
+        - name: HYTALE_CURSEFORGE_RELEASE_CHANNEL
+          value: {{ .Values.curseforge.releaseChannel | quote }}
+        {{- if .Values.curseforge.gameVersionFilter }}
+        - name: HYTALE_CURSEFORGE_GAME_VERSION_FILTER
+          value: {{ .Values.curseforge.gameVersionFilter | quote }}
+        {{- end }}
+        {{- if .Values.curseforge.checkIntervalSeconds }}
+        - name: HYTALE_CURSEFORGE_CHECK_INTERVAL_SECONDS
+          value: {{ .Values.curseforge.checkIntervalSeconds | quote }}
+        {{- end }}
+        - name: HYTALE_CURSEFORGE_PRUNE
+          value: {{ .Values.curseforge.prune | quote }}
+        - name: HYTALE_CURSEFORGE_FAIL_ON_ERROR
+          value: {{ .Values.curseforge.failOnError | quote }}
+        {{- end }}
+        {{- with .Values.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.extraEnvFrom }}
+        envFrom:
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - pgrep -f 'java.*HytaleServer.jar' > /dev/null
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - pgrep -f 'java.*HytaleServer.jar' > /dev/null
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        {{- end }}
+      volumes:
+      - name: data
+        {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim | default (include "hytale-server.fullname" .) }}
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+      restartPolicy: Always
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/k8s/helm/hytale-server/templates/persistentvolumeclaim.yaml
+++ b/k8s/helm/hytale-server/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "hytale-server.fullname" . }}
+  labels:
+    {{- include "hytale-server.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+  - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/k8s/helm/hytale-server/templates/secret.yaml
+++ b/k8s/helm/hytale-server/templates/secret.yaml
@@ -1,0 +1,19 @@
+{{- if or .Values.hytale.sessionToken .Values.hytale.identityToken .Values.curseforge.apiKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "hytale-server.fullname" . }}-secrets
+  labels:
+    {{- include "hytale-server.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.hytale.sessionToken }}
+  session-token: {{ .Values.hytale.sessionToken | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.hytale.identityToken }}
+  identity-token: {{ .Values.hytale.identityToken | b64enc | quote }}
+  {{- end }}
+  {{- if and .Values.curseforge.enabled .Values.curseforge.apiKey (not .Values.curseforge.apiKeySecret.name) }}
+  curseforge-api-key: {{ .Values.curseforge.apiKey | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/k8s/helm/hytale-server/templates/service.yaml
+++ b/k8s/helm/hytale-server/templates/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "hytale-server.fullname" . }}
+  labels:
+    {{- include "hytale-server.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: quic
+    protocol: {{ .Values.service.protocol }}
+    name: quic
+  selector:
+    {{- include "hytale-server.selectorLabels" . | nindent 4 }}

--- a/k8s/helm/hytale-server/templates/serviceaccount.yaml
+++ b/k8s/helm/hytale-server/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "hytale-server.serviceAccountName" . }}
+  labels:
+    {{- include "hytale-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/k8s/helm/hytale-server/values.yaml
+++ b/k8s/helm/hytale-server/values.yaml
@@ -1,0 +1,166 @@
+replicaCount: 1
+
+image:
+  repository: hybrowse/hytale-server
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: false
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  runAsNonRoot: true
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: LoadBalancer
+  port: 5520
+  protocol: UDP
+  annotations: {}
+  loadBalancerIP: ""
+  externalTrafficPolicy: Local
+
+resources:
+  requests:
+    memory: "4Gi"
+    cpu: "2000m"
+  limits:
+    memory: "8Gi"
+    cpu: "4000m"
+
+persistence:
+  enabled: true
+  # existingClaim: ""
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 20Gi
+  annotations: {}
+
+# Hytale server configuration
+hytale:
+  # Auto-download server files using the official downloader
+  autoDownload: true
+  autoUpdate: true
+
+  # Authentication mode: authenticated or offline
+  authMode: authenticated
+
+  bind: "0.0.0.0:5520"
+
+  # Disable Sentry error reporting (recommended for plugin development)
+  disableSentry: false
+
+  # Accept early plugins (acknowledges unsupported plugins)
+  acceptEarlyPlugins: false
+
+  backup:
+    enabled: false
+    dir: ""
+    frequencyMinutes: 30
+    maxCount: 5
+
+  allowOp: true
+  bare: false
+  bootCommand: ""
+  disableAssetCompare: false
+  disableCpbBuild: false
+  disableFileWatcher: false
+  eventDebug: false
+  forceNetworkFlush: true
+  generateSchema: false
+  singleplayer: false
+  validateAssets: false
+  validateWorldGen: false
+
+  earlyPluginsPath: ""
+  modsPath: ""
+  prefabCachePath: ""
+  universePath: ""
+  worldGenPath: ""
+
+  ownerName: ""
+  ownerUUID: ""
+
+  sessionToken: ""
+  identityToken: ""
+
+  downloader:
+    patchline: ""
+    skipUpdateCheck: false
+    keepGameZip: false
+
+jvm:
+  xms: "2G"
+  xmx: "4G"
+  extraArgs: ""
+
+aot:
+  enabled: auto # auto|true|false|generate
+
+curseforge:
+  enabled: false
+  apiKey: ""
+  # Use secret for API key in production
+  apiKeySecret:
+    name: ""
+    key: "curseforge-api-key"
+  mods: []
+  # Example:
+  # - "advanced-item-info"
+  # - "project-id:12345"
+  # - "slug:my-mod@1.0.0"
+  autoUpdate: true
+  releaseChannel: release # release|beta|alpha|any
+  gameVersionFilter: ""
+  checkIntervalSeconds: 0
+  prune: false
+  failOnError: false
+
+extraEnv: []
+# - name: CUSTOM_VAR
+#   value: "custom-value"
+
+extraEnvFrom: []
+# - secretRef:
+#     name: my-secret
+# - configMapRef:
+#     name: my-configmap
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Probes configuration
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 300
+  periodSeconds: 60
+  timeoutSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 60
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3

--- a/k8s/kustomize/base/deployment.yaml
+++ b/k8s/kustomize/base/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hytale-server
+  namespace: hytale
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: hytale-server
+  template:
+    metadata:
+      labels:
+        app: hytale-server
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: hytale-server
+          image: hybrowse/hytale-server:latest
+          stdin: true
+          tty: true
+          ports:
+            - name: quic
+              containerPort: 5520
+              protocol: UDP
+          env:
+            - name: HYTALE_AUTO_DOWNLOAD
+              value: "true"
+            - name: HYTALE_BIND
+              value: "0.0.0.0:5520"
+            - name: HYTALE_AUTH_MODE
+              value: "authenticated"
+            - name: JVM_XMS
+              value: "2G"
+            - name: JVM_XMX
+              value: "4G"
+          resources:
+            requests:
+              memory: "4Gi"
+              cpu: "2000m"
+            limits:
+              memory: "8Gi"
+              cpu: "4000m"
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f 'java.*HytaleServer.jar' > /dev/null
+            initialDelaySeconds: 300
+            periodSeconds: 60
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pgrep -f 'java.*HytaleServer.jar' > /dev/null
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: hytale-server-data
+      restartPolicy: Always

--- a/k8s/kustomize/base/kustomization.yaml
+++ b/k8s/kustomize/base/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: hytale
+
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - persistentvolumeclaim.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/name: hytale-server
+      app.kubernetes.io/managed-by: kustomize

--- a/k8s/kustomize/base/namespace.yaml
+++ b/k8s/kustomize/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hytale

--- a/k8s/kustomize/base/persistentvolumeclaim.yaml
+++ b/k8s/kustomize/base/persistentvolumeclaim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hytale-server-data
+  namespace: hytale
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  # Uncomment and set your storage class if needed
+  # storageClassName: standard

--- a/k8s/kustomize/base/service.yaml
+++ b/k8s/kustomize/base/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hytale-server
+  namespace: hytale
+spec:
+  type: LoadBalancer
+  selector:
+    app: hytale-server
+  ports:
+    - name: quic
+      protocol: UDP
+      port: 5520
+      targetPort: 5520

--- a/k8s/kustomize/overlays/development/deployment-patch.yaml
+++ b/k8s/kustomize/overlays/development/deployment-patch.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hytale-server
+spec:
+  template:
+    spec:
+      containers:
+        - name: hytale-server
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "1000m"
+            limits:
+              memory: "4Gi"
+              cpu: "2000m"
+          env:
+            - name: HYTALE_DISABLE_SENTRY
+              value: "true"
+            - name: HYTALE_AUTH_MODE
+              value: "offline"
+            - name: HYTALE_AUTO_UPDATE
+              value: "false"
+            - name: JVM_XMS
+              value: "2G"
+            - name: JVM_XMX
+              value: "4G"

--- a/k8s/kustomize/overlays/development/kustomization.yaml
+++ b/k8s/kustomize/overlays/development/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+nameSuffix: -dev
+
+patches:
+  - path: deployment-patch.yaml
+    target:
+      kind: Deployment
+      name: hytale-server

--- a/k8s/kustomize/overlays/production/deployment-patch.yaml
+++ b/k8s/kustomize/overlays/production/deployment-patch.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hytale-server
+spec:
+  template:
+    spec:
+      containers:
+        - name: hytale-server
+          resources:
+            requests:
+              memory: "8Gi"
+              cpu: "4000m"
+            limits:
+              memory: "16Gi"
+              cpu: "8000m"
+          env:
+            - name: HYTALE_ENABLE_BACKUP
+              value: "true"
+            - name: HYTALE_BACKUP_FREQUENCY_MINUTES
+              value: "60"
+            - name: HYTALE_BACKUP_MAX_COUNT
+              value: "10"
+            - name: HYTALE_AUTO_UPDATE
+              value: "true"
+            - name: JVM_XMS
+              value: "4G"
+            - name: JVM_XMX
+              value: "8G"

--- a/k8s/kustomize/overlays/production/kustomization.yaml
+++ b/k8s/kustomize/overlays/production/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+nameSuffix: -prod
+
+patches:
+  - path: deployment-patch.yaml
+    target:
+      kind: Deployment
+      name: hytale-server


### PR DESCRIPTION
## Summary

## Checklist

- [x] I have the right to submit this work under the repository license.
- [x] I did not include proprietary Hytale server binaries/assets.
- [x] I did not include credentials, tokens, or other secrets.
- [x] Docs were updated if behavior changed.
- [x] I ran relevant checks locally (if applicable).

## Sign-off (DCO)

By submitting this pull request, I certify that I have the right to contribute this work and agree to license it under the repository license.

## PR Content : Implement helm charts, kustomize files and ci tests for k8s deployments

This pull request introduces a full Kubernetes Helm chart for deploying a Hytale dedicated server, along with a comprehensive GitHub Actions workflow for validating Kubernetes resources. The changes include all the necessary Helm chart files (templates, helpers, configuration, and documentation), a `.helmignore` for packaging, and automated CI checks for Helm, Kustomize, YAML, and Kubernetes manifest validation.

The most important changes are:

**Helm Chart Introduction:**

* Added a complete Helm chart for `hytale-server`, including `Chart.yaml`, deployment, persistent volume claim, secrets, helper templates, and user notes, enabling standardized and configurable Kubernetes deployments.

* Added a `.helmignore` file to exclude unnecessary files from the Helm package, improving chart cleanliness and security.

**Kubernetes CI/CD Automation:**

* Introduced a new GitHub Actions workflow (`k8s-validation.yml`) to automatically lint Helm charts, validate Kustomize overlays, lint YAML files, and check Kubernetes manifests for schema compliance and deprecated fields. This ensures all Kubernetes resources remain valid and up-to-date as part of the development workflow.

## Additionnal thinking

Due to Hytale server startup process that require first start to authenticate the "production" capacity of this deployment is limited by the first actions that have to be made by hand.
Some additionnal work will be necessary to make it production-ready and scalable to avoid those setup steps in the future.

Having helm charts and kustomize deployment is a good thing because helm is not always installed on end-users machines but kustomize in bundled with kubectl through the parameter `-k` natively.